### PR TITLE
Fix gm identer

### DIFF
--- a/pre-migration/identer/parse_idents.py
+++ b/pre-migration/identer/parse_idents.py
@@ -40,7 +40,7 @@ def parse_ident_type(ident: str, region: str) -> str:
     if re.match("^81\s?\d{3}$", ident) and region not in REGIONS:
         return "jessen"
 
-    if re.match("^G\.[IM]\.\d{4}(/\d{4}(.\d)?)?$", ident):
+    if re.match("^G\.[IM]\.\d{3,4}(/\d{4})?(.\d)?$", ident):
         return "GI"
 
     if re.match("^\d{4}/\w", ident):
@@ -152,6 +152,7 @@ def test():
         ("DK", "G.I.1452"): "GI",
         ("DK", "G.M.1166.1"): "GI",
         ("DK", "G.M.110"): "GI",
+        ("DK", "24-01-00032.1"): "landsnr",
 
     }
 


### PR DESCRIPTION
Forbedr tolkningen af G.M.-identer

G.M.-identer med løbenummer mindre end 1000 blev ikke tolket korrekt. Dette er nu taget hånd om, sådan at også 3-cifrede løbenumre tages i betragtning.

Løser https://github.com/Kortforsyningen/FIRE/issues/198.