### PR TITLE
Afrund apriorispredning til 2 decimaler

### DIFF
--- a/Migration/MakeObservation.sql
+++ b/Migration/MakeObservation.sql
@@ -117,7 +117,7 @@ SELECT
   obs.S_LENGTH AS VALUE2,
   obs.SET_UP AS VALUE3,
   obs.ETA AS VALUE4,
-  sqrt(1e9*opst.MD) AS VALUE5,
+  round(sqrt(1e9*opst.MD), 2) AS VALUE5,
   sqrt(opst.MC)*1000 AS VALUE6,
   0 AS VALUE7,
   NULL AS VALUE8,
@@ -170,7 +170,7 @@ SELECT
   obs.S_LENGTH AS VALUE2,
   obs.SET_UP AS VALUE3,
   obs.ETA AS VALUE4,
-  sqrt(1e9*opst.MD) AS VALUE5,
+  round(sqrt(1e9*opst.MD), 2) AS VALUE5,
   sqrt(opst.MC)*1000 AS VALUE6,
   CASE
     WHEN opst.YEAR BETWEEN 1885 AND 1910 THEN 1
@@ -226,7 +226,7 @@ SELECT
   obs.OBS AS VALUE1,
   obs.S_LENGTH AS VALUE2,
   obs.SET_UP AS VALUE3,
-  sqrt(1e9*opst.MD) AS VALUE4,
+  round(sqrt(1e9*opst.MD), 2) AS VALUE4,
   sqrt(opst.MC)*1000 AS VALUE5,
   NULL AS VALUE6,
   NULL AS VALUE7,


### PR DESCRIPTION
Apriorispredningen på nivellementsobservationer følger et nøje, erfaringsbaseret mønster, baseret på tierpotenser af små heltal. Desværre er nogle af disse blevet fejlafrundet under indsætning i REFGEO. Det retter vi op på her.